### PR TITLE
Fixed typo in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 <a name="bm" />
 ## BM
 
@@ -55,8 +54,8 @@ Commands:
   $ bm
 
   # view bookmark screenshots in your default browser
-  $ vm view design
-  $ vm view
+  $ bm view design
+  $ bm view
 
   # clear all bookmarks
   $ bm clear


### PR DESCRIPTION
Change 'vm' to 'bm' under usage command
