### PR TITLE
Corrected a typo in the Usage-note

### DIFF
--- a/bin/bm
+++ b/bin/bm
@@ -54,8 +54,8 @@ usage() {
     $ bm stats
 
     # view bookmark screenshots in your default browser
-    $ vm view design
-    $ vm view
+    $ bm view design
+    $ bm view
 
     # clear all bookmarks
     $ bm clear


### PR DESCRIPTION
Replaced 'vm' with 'bm'
